### PR TITLE
refactor: improve API to calculate pore metrics

### DIFF
--- a/pymks/atommks/scripts/tutorial_poreMKS.ipynb
+++ b/pymks/atommks/scripts/tutorial_poreMKS.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "scrolled": true
    },
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "scrolled": true
    },
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -180,7 +180,7 @@
        "Atoms(symbols='O1920Si960', pbc=True, cell=[[27.59, 0.0, 0.0], [-13.794999999999995, 23.893640890412662, 0.0], [0.0, 0.0, 81.5]], spacegroup_kinds=...)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -207,7 +207,7 @@
        "{'O': 1.52, 'Si': 2.1}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -234,7 +234,7 @@
        "2880"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -285,7 +285,7 @@
        "dict_keys(['pores', 'n_pixel', 'O', 'Si'])"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -312,7 +312,7 @@
        "(277, 240, 813)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -325,7 +325,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Compute Conventional Pore Metrics - PLD and LCD"
+    "## Compute Conventional Pore Metrics - PLD and LCD\n",
+    "\n",
+    "Here we compute two pore metrics, the pore limiting diameter (PLD) and the largest cavity diameter (LCD). The PLD refers to the maximum size of a molecule that can pass through the structure in a particular direction.\n",
+    "\n",
+    "We use the `calc_pore_metrics` function to calculate the pore metrics. Internally, this uses the Euclidean distance from the pore phase to the nearest atom. This calculation is direction dependent as the PLD \n",
+    "calculation simulates a probe molecule traversing the structure in a particular direction (by default the direction is assumed to be the last axis, i.e. z-direction for 3D structures)."
    ]
   },
   {
@@ -336,55 +341,7 @@
     {
      "data": {
       "text/plain": [
-       "array([[[0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        ...,\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ]],\n",
-       "\n",
-       "       [[0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        ...,\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ]],\n",
-       "\n",
-       "       [[0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
-       "        ...,\n",
-       "        [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ]],\n",
-       "\n",
-       "       ...,\n",
-       "\n",
-       "       [[0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
-       "        ...,\n",
-       "        [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ]],\n",
-       "\n",
-       "       [[0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        ...,\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0.1, 0.1, 0.1, ..., 0.1, 0.1, 0.1],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ]],\n",
-       "\n",
-       "       [[0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        ...,\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ],\n",
-       "        [0. , 0. , 0. , ..., 0. , 0. , 0. ]]])"
+       "{'pld': 2.1953125, 'lcd': 7.573638491504594}"
       ]
      },
      "execution_count": 20,
@@ -393,83 +350,34 @@
     }
    ],
    "source": [
-    "S_dgrid"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "distance grid computation time: 10.223s\n",
-      "PLD: 2.195\n",
-      "PLD computation time: 3.673s\n",
-      "LCD: 7.574\n",
-      "LCD computation time: 0.028s\n"
-     ]
-    }
-   ],
-   "source": [
-    "strt = time.time()\n",
-    "padval = ((1, 1), (1, 1), (0, 0)) \n",
-    "S_dgrid = pipe(grids['pores'],\n",
-    "               lambda s: np.pad(s, padval, 'constant', constant_values=0),\n",
-    "               lambda s: pore.dgrid(s, len_pixel=grid_data['n_pixel']))\n",
-    "end = time.time()\n",
-    "print(\"distance grid computation time: %1.3fs\"%(end-strt))\n",
-    "\n",
-    "strt = time.time()\n",
-    "pld  = pore.get_pld(S_dgrid)\n",
-    "end  = time.time()\n",
-    "print(\"PLD: %1.3f\" % pld)\n",
-    "print(\"PLD computation time: %1.3fs\"%(end-strt))\n",
-    "\n",
-    "strt = time.time()\n",
-    "lcd  = pore.get_lcd(S_dgrid)\n",
-    "end  = time.time()\n",
-    "print(\"LCD: %1.3f\" % lcd)\n",
-    "print(\"LCD computation time: %1.3fs\"%(end-strt))"
+    "pore.calc_pore_metrics(grid_data['pores'], n_pixel=grid_data['n_pixel'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### For PLD in a different direction"
+    "The PLD values will be different in the x-direction for example (`axis=0` signifies the x-direction)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4.3046875\n",
-      "CPU times: user 10.6 s, sys: 860 ms, total: 11.5 s\n",
-      "Wall time: 11.5 s\n"
-     ]
+     "data": {
+      "text/plain": [
+       "{'pld': 3.4609375, 'lcd': 7.194442299441979}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "%%time\n",
-    "padval = ((1, 1), (1, 1), (0, 0)) \n",
-    "pld = pipe(S, \n",
-    "           lambda s: np.rot90(s, axes=(0,2)),\n",
-    "           lambda s: np.pad(s, padval, 'constant', constant_values=0),\n",
-    "           lambda s: pore.dgrid(s, len_pixel=len_pixel),\n",
-    "           lambda s: pore.get_pld(s))\n",
-    "print(pld)"
+    "pore.calc_pore_metrics(grid_data['pores'], n_pixel=grid_data['n_pixel'], axis=0)"
    ]
   },
   {
@@ -880,7 +788,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Improve the API to calculate the pore metrics. Simplify the
calculation by removing the Euclidean distance calculation from the
notebook and complicated rotations and padding. This is all done
internally now and not in the notebook.